### PR TITLE
docker additions for running Dashboard in the datacube container

### DIFF
--- a/easi-pc-py36/Dockerfile.dashboard
+++ b/easi-pc-py36/Dockerfile.dashboard
@@ -1,0 +1,138 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="CSIRO EASI Data Cube Training on PC <Robert.Woodcock@csiro.au>"
+
+USER root
+
+# A littel apt configuration to speed downloads a little
+ADD 99parallel /etc/apt/apt.conf.d/99parallel
+
+# Switch to Australian mirror for ubuntu apt packages
+RUN sed --in-place --regexp-extended "s/(\/\/)(archive\.ubuntu)/\1au.\2/" /etc/apt/sources.list && \
+	apt-get update && apt-get upgrade --yes
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# First add the NextGIS repo
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN add-apt-repository ppa:nextgis/ppa
+
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+    # Core requirements from travis.yml
+    gdal-bin gdal-data libgdal-dev libgdal20 libudunits2-0 \
+    # Extra python components, to speed things up
+    python3 python3-setuptools python3-dev \
+    python3-numpy python3-netcdf4 python3-gdal \
+    # Need pip to install more python packages later.
+    # The libdpkg-perl is needed to build pyproj
+    python3-pip python3-wheel libdpkg-perl \
+    # Git to work out the ODC version number
+    git \
+    # G++ because GDAL decided it needed compiling
+    g++ \
+    # numpy requires headers for cf_units
+    libudunits2-dev \
+    # Additional utilities useful for ODC dev
+	postgresql-client \
+	curl \
+    wget \
+    bzip2 \
+    ca-certificates \
+    sudo \
+    locales \
+    fonts-liberation \
+    ffmpeg \
+    # OS dependencies for fully functional Jupyter notebook server
+    build-essential \
+    emacs \
+    inkscape \
+    jed \
+    libsm6 \
+    libxext-dev \
+    libxrender1 \
+    lmodern \
+    netcat \
+    pandoc \
+    texlive-fonts-extra \
+    texlive-fonts-recommended \
+    texlive-generic-recommended \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-xetex \
+    unzip \
+    nano \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure Jupyter Notebook
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+# Configure environment
+ENV SHELL=/bin/bash \
+    NB_USER=jovyan \
+    NB_UID=1000 \
+    NB_GID=100 \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
+ENV HOME=/home/$NB_USER
+
+ADD fix-permissions /usr/local/bin/fix-permissions
+# Create jovyan user with UID=1000 and in the 'users' group
+# and make sure these dirs are writable by the `users` group.
+RUN groupadd wheel -g 11 && \
+    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    chmod g+w /etc/passwd && \
+    /bin/bash fix-permissions $HOME
+
+# Install Tini.. this is required because CMD (below) doesn't play nice with notebooks for some reason: https://github.com/ipython/ipython/issues/7062, https://github.com/jupyter/notebook/issues/334
+RUN curl -L https://github.com/krallin/tini/releases/download/v0.10.0/tini > tini && \
+    echo "1361527f39190a7338a0b434bd8c88ff7233ce7b9a4876f3315c22fce7eca1b0 *tini" | sha256sum -c - && \
+    mv tini /usr/local/bin/tini && \
+    chmod +x /usr/local/bin/tini
+
+USER $NB_UID
+
+# Setup work directory for backward-compatibility
+RUN mkdir $HOME/work && \
+    mkdir $HOME/odc && \
+    /bin/bash fix-permissions $HOME
+
+# Install psycopg2 as a special case, to quiet the warning message 
+RUN pip3 install --no-cache --no-binary :all: psycopg2
+
+# Install jupyter notebook and additional python packages for interactive odc use
+RUN pip3 install jupyter matplotlib folium ffmpeg shapely scikit-image
+
+RUN ~/.local/bin/jupyter notebook --generate-config && \
+    rm -rf $HOME/.cache/yarn && \
+    /bin/bash fix-permissions $HOME
+
+USER root
+
+EXPOSE 8888
+
+# Configure container startup
+ENTRYPOINT ["/usr/local/bin/tini", "-g", "--"]
+
+# launch notebook
+#CMD ["/bin/bash", "start-notebook.sh"]
+CMD ["/bin/bash", "start-notebook.sh", "with-dashboard"]
+EXPOSE 8998
+
+# Add local files as late as possible to avoid cache busting
+COPY start.sh /usr/local/bin/
+COPY jupyter_notebook_config.py /etc/jupyter/
+RUN /bin/bash fix-permissions /etc/jupyter/
+COPY start-notebook.sh /usr/local/bin/
+COPY start-dashboard.sh /usr/local/bin/
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER $NB_UID
+

--- a/easi-pc-py36/docker-compose.yml.dashboard
+++ b/easi-pc-py36/docker-compose.yml.dashboard
@@ -1,0 +1,39 @@
+version: '3.4'
+
+services:
+  postgres:
+    image: mdillon/postgis:11-alpine
+#    image: postgres:alpine
+    environment:
+      - POSTGRES_DB=odc
+      - POSTGRES_USER=odc
+      - POSTGRES_PASSWORD=eev2
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  opendatacube:
+    image: csiroeasi/easi-training-pc:latest
+    depends_on:
+      - postgres
+    environment:
+      - DISPLAY
+    ports:
+     - "8888:8888"
+     - "8998:8998"
+    volumes:
+      - ../datacube-core:/home/jovyan/odc
+      - ../../sample_data:/data
+      - ../output:/home/jovyan/output
+      - ../work:/home/jovyan/work
+      - ./config/datacube.conf:/home/jovyan/.datacube.conf
+      - ./config/datacube.conf:/etc/datacube.conf
+      - ./config/datacube_integration.conf:/home/jovyan/.datacube_integration.conf
+    
+    stdin_open: true
+    tty: true
+
+volumes: 
+  postgres-data:
+    name: easi-training-pc-postgres-data

--- a/easi-pc-py36/start-dashboard.sh
+++ b/easi-pc-py36/start-dashboard.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Drop out on any error
+set -e
+
+# Install Dashboard deploy environment - only once
+if [ ! $(pip3 freeze 2> /dev/null | grep dashboard) ]; then
+    # Now use the setup.py file to identify dependencies
+    cd $HOME/work/dea-dashboard
+#    export CPLUS_INCLUDE_PATH=/usr/include/gdal
+#    export C_INCLUDE_PATH=/usr/include/gdal
+
+#    apt-get update && apt-get install -y \
+#        python3-fiona python3-shapely \
+#        && rm -rf /var/lib/apt/lists/*
+        
+    pip3 install gunicorn flask pyorbital colorama
+
+    pip3 install -e .[deployment]
+
+    # To be updated after the dashboard install
+    pip3 install -U  cligj \
+        && rm -rf $HOME/.cache/pip
+fi
+
+cd $HOME
+if [ -d "product-summaries" ]; then
+    rm -rf "product-summaries"
+fi
+mkdir "product-summaries"
+
+cubedash-gen --all | tee -a $HOME/summary-gen.log
+
+gunicorn -b '0.0.0.0:8998' -w 1 '--worker-class=egg:meinheld#gunicorn_worker'  --timeout 60 cubedash:app &

--- a/easi-pc-py36/start-notebook.sh
+++ b/easi-pc-py36/start-notebook.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+
+# Drop out on any error
 set -e
+
 # Install ODC dev environment - only once
 if [ ! $(pip3 freeze 2> /dev/null | grep datacube==) ]; then
     # Now use the setup.py file to identify dependencies
@@ -16,6 +19,7 @@ if [ ! $(pip3 freeze 2> /dev/null | grep datacube==) ]; then
     # Add missing python packages that are required for things like data inges
     pip3 install pandas geopandas
 fi
+
 # Update path
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
   export PATH=$HOME/.local/bin:$PATH
@@ -23,7 +27,16 @@ if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
 else
   echo PATH is fine. $PATH
 fi
+
+# Optionally install the Dashboard. Requires postgis
+if [ "$1" == "with-dashboard" ]; then
+    echo Invoking start-dashboard.sh
+    /bin/bash /usr/local/bin/start-dashboard.sh
+    shift  # pop "with-dashboard"
+fi
+
 # Start Jupyter Notebook
 cd $HOME/work
 
-/usr/local/bin/start.sh ~/.local/bin/jupyter notebook --NotebookApp.token='secretpassword' $*
+/bin/bash /usr/local/bin/start.sh $HOME/.local/bin/jupyter notebook --NotebookApp.token='secretpassword' $*
+


### PR DESCRIPTION
Refactoring out the dashboard component into a separate image can happen later. For now, the dashboard and notebooks can run out of the same container.

Usage:

1. Swap `Dockerfile.dashboard` and `docker-compose.yml.dashboard` for their non-dashboard counterparts.

- Note that `docker-compose.yml.dashboard` uses a postgis image, rather than the standard postgres image.

1. After `docker-compose up -d` do `docker logs easi-pc-py36_opendatacube_1` to ensure there are no errors.

1. In a browser go to `localhost:8888` for notebooks and `localhost:8998` for dashboard.

1. If new products or datasets are added, then `cubedash-gen --all` will likely need to be re-run from inside the container.